### PR TITLE
Draft: Build in GitHub action

### DIFF
--- a/install-fuzzer-builder/README.md
+++ b/install-fuzzer-builder/README.md
@@ -1,0 +1,18 @@
+# Install Fuzzer Build Tools
+
+This action installs ci-build and dependant tools into the current workspace.
+Subsequent action can access the `ci-fuzz/bin/ci-build` binary to build a fuzzing artifact.
+
+## Outputs
+
+The tools are installed into `{{ github.workspace }}/ci-fuzz`.
+
+## Example usage
+
+```yaml
+- id: install-build-tools
+  uses: CodeIntelligenceTesting/github-actions/install-fuzzer-builder@v3
+- id: build-fuzzers
+  run: ci-fuzz/bin/ci-build fuzzers --directory $GITHUB_WORKSPACE/checkout-dir/ 
+  shell: "bash"
+```

--- a/install-fuzzer-builder/action.yml
+++ b/install-fuzzer-builder/action.yml
@@ -1,0 +1,6 @@
+
+name: "Install Fuzzer Build Tools"
+description: "Installs ci-build and dependant tools into the current workspace."
+runs:
+  using: "docker"
+  image: "docker://cifuzz/build-tools-installer:latest"

--- a/monitor-fuzzing/action.yml
+++ b/monitor-fuzzing/action.yml
@@ -19,7 +19,7 @@ inputs:
   timeout:
     description: "Timeout (in seconds) to monitor the fuzzing. If no crash was found when it times out, the action is considered successful."
     required: false
-    default: 300
+    default: "300"
   findings_type:
     description: "Comma separated types of findings to monitor. Accepted values: UNKNOWN_ERROR, COMPILATION_ERROR, CRASH, WARNING, RUNTIME_ERROR."
     required: false
@@ -34,12 +34,16 @@ inputs:
     default: "https://app.code-intelligence.com"
   github_token:
     description: "GitHub token used by the GitHub API to create a comment in a pull request with a link to the finding"
+    required: false
   pull_request_number:
     description: "Number of the pull request where the comment with the finding link will be created"
+    required: false
   owner:
     description: "Owner of the repository that contains the pull request"
+    required: false
   repository:
     description: "Repository that contains the pull request"
+    required: false
 runs:
   using: "docker"
   image: "docker://cifuzz/github-action:v3"

--- a/start-fuzzing/action.yml
+++ b/start-fuzzing/action.yml
@@ -12,10 +12,10 @@ inputs:
     required: false
   project:
     description: "Name of the project"
-    required: true
+    required: false
   test_collection:
     description: "Name of the Test Collection in the specified project"
-    required: true
+    required: false
   report_email:
     description: "E-mail to receive crash reports"
     required: false
@@ -25,6 +25,7 @@ inputs:
     default: "grpc-api.code-intelligence.com:443"
   git_reference:
     description: "Git reference used when pulling code from the repository to be fuzzed"
+    required: false
 runs:
   using: "docker"
   image: "docker://cifuzz/github-action:v3"

--- a/start-fuzzing/action.yml
+++ b/start-fuzzing/action.yml
@@ -16,6 +16,13 @@ inputs:
   test_collection:
     description: "Name of the Test Collection in the specified project"
     required: false
+  fuzzing_artifact:
+    description: "Fuzzing artifact path. Used when building the fuzzing artifact in a github workflow."
+    required: false
+  checkout_directory:
+    description: "Directory of the repository checkout. Relative to the github workspace. Defaults to the github workspace."
+    required: false
+    default: ""
   report_email:
     description: "E-mail to receive crash reports"
     required: false


### PR DESCRIPTION
Adds the "install-fuzzer-builder" action that copies the build tools into the current workspace, making them available to build fuzzers in subsequent workflow steps.