### PR TITLE
start-fuzzing: add application_base_url input

### DIFF
--- a/start-fuzzing/README.md
+++ b/start-fuzzing/README.md
@@ -38,6 +38,10 @@ Set this input if you wish to use a fuzzing server other than Code-Intelligence'
 
 Git reference used when pulling code from the repository to be fuzzed.
 
+### `application_base_url`
+
+The base URL of the application under test. Only relevant for web application fuzzing.
+
 ## Outputs
 
 ### `test_collection_run`

--- a/start-fuzzing/action.yml
+++ b/start-fuzzing/action.yml
@@ -33,6 +33,9 @@ inputs:
   git_reference:
     description: "Git reference used when pulling code from the repository to be fuzzed"
     required: false
+  application_base_url:
+    description: "The base URL of the application under test. Only relevant for web application fuzzing."
+    required: false
 runs:
   using: "docker"
   image: "docker://cifuzz/github-action:v3"


### PR DESCRIPTION
Allows users to use the `--application_base_url` flag in `cictl start`.